### PR TITLE
[semver:patch] Specify go version and prep docker for component test

### DIFF
--- a/src/jobs/go-component.yml
+++ b/src/jobs/go-component.yml
@@ -38,7 +38,7 @@ steps:
   - attach_workspace:
       at: ~/repo
   - golang/install:
-    version: <<parameters.go_version>>
+      version: <<parameters.go_version>>
   - golang/gomod-download
   - run:
       name: Set up docker

--- a/src/jobs/go-component.yml
+++ b/src/jobs/go-component.yml
@@ -28,12 +28,22 @@ parameters:
     type: string
     description: "the name of the database to be used for component tests"
     default: component
+  go_version:
+    type: string
+    description: "the version of golang to install"
+    default: "1.15.6"
 
 steps:
   - checkout
   - attach_workspace:
       at: ~/repo
+  - golang/install:
+    version: <<parameters.go_version>>
   - golang/gomod-download
+  - run:
+      name: Set up docker
+      command: |
+        echo "$DOCKER_PASS" | docker login --username "$DOCKER_USER" --password-stdin
   - when:
       condition: <<parameters.rabbit>>
       steps:

--- a/src/scripts/start-postgres.sh
+++ b/src/scripts/start-postgres.sh
@@ -9,9 +9,6 @@ until docker-compose exec postgres pg_isready; do
   sleep 1
 done
 
-docker-compose up -d migrate
-
-# wait for migrations
-docker-compose logs -f migrate
+docker-compose run migrate
 
 echo "export POSTGRES_URL=postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@localhost:$POSTGRES_PORT/$POSTGRES_DB?sslmode=disable" >> "$BASH_ENV"


### PR DESCRIPTION
#### Card  BishopFox/product-eng#990

#### Details

This fixes a bug identified in pulling a BishofFox docker image that isn't built from this repo during component tests.

It also allows specifying the version of Go to install so that we're not at the mercy of whatever Ubuntu's default is