### PR TITLE
[semver:minor] Publish latest & stable tags for all containers

### DIFF
--- a/src/scripts/publish-docker.sh
+++ b/src/scripts/publish-docker.sh
@@ -1,7 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+
 VERSION=$(cat VERSION)
 if [[ -z $VERSION ]]; then
-  echo "no VERSION file present"
-  exit 1
+    echo "no VERSION file present"
+    exit 1
 fi
 
 CONTAINER="bishopfox/$RELEASE_NAME"
@@ -9,33 +13,32 @@ CONTAINER="bishopfox/$RELEASE_NAME"
 VERSIONED_TAG="$VERSION"
 NAMED_TAG="stable"
 if [[ -n $CANDIDATE ]]; then
-  VERSIONED_TAG="$VERSIONED_TAG-$CIRCLE_SHA1"
-  NAMED_TAG="latest"
+    VERSIONED_TAG="$VERSIONED_TAG-$CIRCLE_SHA1"
+    NAMED_TAG="latest"
 fi
 
 build() {
-  docker build --pull --no-cache -t "$CONTAINER" .
+    docker build --pull --no-cache -t "$CONTAINER" .
 }
 
 push_version() {
-  local TAG="$1"
+    local TAG="$1"
 
-  docker tag "$CONTAINER:latest" "$TAG"
+    docker tag "$CONTAINER:latest" "$TAG"
 
-  docker push "$TAG"
+    docker push "$TAG"
 }
 
 build_migration() {
-  docker build -t "$CONTAINER:migrate" ./migrations/
+    docker build -t "$CONTAINER:migrate" ./migrations/
 }
 
 push_migration() {
-  local TAG="$1"
+    local TAG="$1"
 
-  docker tag "$CONTAINER:migrate" "$TAG"
+    docker tag "$CONTAINER:migrate" "$TAG"
 
-	docker push "$TAG"
-	docker push "$VERSIONED"
+    docker push "$TAG"
 }
 
 
@@ -46,10 +49,8 @@ build
 push_version "$CONTAINER:$VERSIONED_TAG"
 push_version "$CONTAINER:$NAMED_TAG"
 
-push_named
-
 if [[ -f migrations/Dockerfile ]]; then
-  build_migration
-  push_migration "$CONTAINER:migrate-$VERSIONED_TAG"
-  push_migration "$CONTAINER:migrate-$NAMED_TAG"
+    build_migration
+    push_migration "$CONTAINER:migrate-$VERSIONED_TAG"
+    push_migration "$CONTAINER:migrate-$NAMED_TAG"
 fi


### PR DESCRIPTION
#### Card

#### Details

This adds an additional `-stable` tag for non-candidate docker releases so that we car rely on, say, `hawkeye:migrate-stable` in the tests for another system