### PR TITLE
fix help text for failed goimports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.7
+### Fixed
+- Error message provided by `goimports` when it fails to be accurate
+
 ## 0.2.6
 ### Changed
 - improve preflight messaging

--- a/src/commands/goimports.yml
+++ b/src/commands/goimports.yml
@@ -12,6 +12,6 @@ steps:
       name: validate goimports
       command: |
         if [[ "$(goimports -local 'github.com/BishopFox' -l . | tee /dev/stderr)" ]];  then
-          echo "Fix formatting issues with 'goimports .'"
+          echo "Fix formatting issues with `goimports -local 'github.com/BishopFox' -w .`"
           exit 1
         fi


### PR DESCRIPTION
#### Card no

#### Details
The help text for failing goimports is incorrect. Running it as-is will result in conflicts with the checks actually performed by the orb, which place `BishopFox` local imports in a different location.

This updates the help text to be consistent.