### PR TITLE
Don't run goimports, report the command to be run

### DIFF
--- a/src/commands/goimports.yml
+++ b/src/commands/goimports.yml
@@ -12,6 +12,6 @@ steps:
       name: validate goimports
       command: |
         if [[ "$(goimports -local 'github.com/BishopFox' -l . | tee /dev/stderr)" ]];  then
-          echo "Fix formatting issues with `goimports -local 'github.com/BishopFox' -w .`"
+          echo 'Fix formatting issues with `goimports -local "github.com/BishopFox" -w .`'
           exit 1
         fi


### PR DESCRIPTION
#### Card

#### Details

This always meant to echo 
```
Fix formatting issues with `goimports -local 'github.com/BishopFox' -w .`
```
but since the grave characters were contained within a double-quoted string bash executed the command instead of echoing.

This replaces the double quotes with single quotes to prevent that :)
