### PR TITLE
Update the default golang tag and let it be configure

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -7,6 +7,6 @@ display:
   source_url: "https://www.github.com/BishopFox/guardian-ci"
 
 orbs:
-  golang: cci-orb/golang@0.1.15
-  aws-cli: circleci/aws-cli@1.4.0
-  terraform: circleci/terraform@1.2.0
+  golang: cci-orb/golang@0
+  aws-cli: circleci/aws-cli@1
+  terraform: circleci/terraform@1

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,5 +1,14 @@
+description: >
+    Golang docker executor
 docker:
-  - image: cimg/go:1.15.2
-    auth:
-      username: $DOCKER_USER
-      password: $DOCKER_PASS
+    - image: "cimg/go:<<parameters.tag>>"
+      auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+parameters:
+    tag:
+        default: "1.16.5"
+        description: >
+            Pick a specific cimg/python image variant:
+            https://hub.docker.com/r/cimg/python/tags
+        type: string


### PR DESCRIPTION
#### Card https://github.com/BishopFox/product-eng/issues/1324

#### Details

This updates our default Golang version to 1.16.5 and lets individual repos override that value when necessary.