### PR TITLE
[semver:patch] disable module version enforcement

### DIFF
--- a/src/scripts/vet-tf.sh
+++ b/src/scripts/vet-tf.sh
@@ -13,7 +13,7 @@ find_modules () {
 vet_terraform () {
   eval "${TERRAFORM}" fmt --check . || (echo "Terraform is not formatted correctly. Please run 'terraform fmt'" && exit 1)
 
-  latest_module_version="v$(cat "${TF_MODULE_DIR}"/VERSION)"
+  #latest_module_version="v$(cat "${TF_MODULE_DIR}"/VERSION)"
 
   if ! (find_modules >/dev/null); then
     echo "no modules found"

--- a/src/scripts/vet-tf.sh
+++ b/src/scripts/vet-tf.sh
@@ -20,17 +20,17 @@ vet_terraform () {
     exit 0
   fi
 
-  tf_versions=$(find_modules | grep -oP '(?<=ref=)v[0-9\.]+')
+  #tf_versions=$(find_modules | grep -oP '(?<=ref=)v[0-9\.]+')
 
-  if [[ -n $tf_versions ]]; then
-  echo "$tf_versions" | while read -r version; do
-    if [[ "$latest_module_version" != "$version" ]]; then
-    echo "terraform modules can be upgraded from $version to $latest_module_version"
-    echo "if it cannot be upgraded, remove this job from the pipeline and re-add it when modules can be upgraded"
-    exit 1
-    fi
-  done
-  fi
+  #if [[ -n $tf_versions ]]; then
+  #echo "$tf_versions" | while read -r version; do
+  #  if [[ "$latest_module_version" != "$version" ]]; then
+  #  echo "terraform modules can be upgraded from $version to $latest_module_version"
+  #  echo "if it cannot be upgraded, remove this job from the pipeline and re-add it when modules can be upgraded"
+  #  exit 1
+  #  fi
+  #done
+  #fi
 }
 
 TEST_ENV="bats-core"

--- a/src/tests/vet-tf.bats
+++ b/src/tests/vet-tf.bats
@@ -23,10 +23,10 @@ teardown()  {
   (cd /tmp/tf_repo && vet_terraform)
 }
 
-@test 'vet-tf fails when modules are not up to date' {
-  ! (cd /tmp/tf_repo && vet_terraform > /tmp/testlog)
-   grep 'terraform modules can be upgraded' /tmp/testlog
-}
+#@test 'vet-tf fails when modules are not up to date' {
+#  ! (cd /tmp/tf_repo && vet_terraform > /tmp/testlog)
+#   grep 'terraform modules can be upgraded' /tmp/testlog
+#}
 
 @test 'vet-tf fails when terraform is not formatted' {
   export TERRAFORM="false"


### PR DESCRIPTION
#### Card
BishopFox/product-eng#1589

#### Details
This update disables terraform module version enforcement. 

After speaking with @kekkerz about various ways of managing versions, we decided that simply disabling enforcement for now is the simplest option. The main downstream services primarily use the ecs-task & lambda modules, which aren't the main focus of current terraform development. Disabling version enforcement will make CI less painful for developers. If we _do_ need to enforce a new version of ecs-task etc., we can simply re-enable it.